### PR TITLE
Support of filenames with query strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ OptimizeCssnanoPlugin.prototype.apply = function(compiler) {
       // Search for CSS assets
       const assetsNames = Object.keys(compilation.assets)
         .filter((assetName) => {
-          return /\.css$/i.test(assetName);
+          return /\.css(\?.*)?$/i.test(assetName);
         });
 
       let hasErrors = false;


### PR DESCRIPTION
It fixes case when hash is used as query string, example ``style.css?bce9ee41``